### PR TITLE
feat: Improve article list page

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,6 +1,6 @@
 class ArticlesController < ApplicationController
   expose(:article)
-  expose(:articles) { Article.all }
+  expose(:articles) { Article.order(created_at: :desc).limit(20) }
 
   def create
     if article.save

--- a/app/views/articles/index.html.haml
+++ b/app/views/articles/index.html.haml
@@ -1,7 +1,7 @@
-%h1 Articles
+%h1 Recent Articles
 
 %p= link_to "New Article", new_article_path
 
 %ul
   - articles.each do |article|
-    %li= article.title
+    %li= link_to article.title, edit_article_path(article)

--- a/spec/system/articles/editor_sees_articles_spec.rb
+++ b/spec/system/articles/editor_sees_articles_spec.rb
@@ -1,13 +1,44 @@
 require 'rails_helper'
 
 describe "articles" do
-  it "lists articles" do
-    articles = FactoryBot.create_list(:article, 3)
-    visit "/articles"
-    expect(page).to have_content "Articles"
+  context "with no articles" do
+    it "renders an empty list" do
+      visit "/articles"
+      expect(page).to have_content "Recent Articles"
+      expect(page).to have_css "ul"
+      expect(page.all("li").count).to eq 0
+    end
+  end
 
-    articles.each do |article|
-      expect(page).to have_css("li", text: article.title)
+  context "with 1 article" do
+    it "lists that article by title with a link" do
+      article = FactoryBot.create(:article)
+      visit "/articles"
+
+      expect(page.all("li").count).to eq 1
+      expect(page).to have_link(article.title)
+    end
+  end
+
+  context "with a few articles" do
+    it "lists those articles" do
+      articles = FactoryBot.create_list(:article, 3)
+      visit "/articles"
+      expect(page.all("li").count).to eq 3
+
+      articles.each do |article|
+        expect(page).to have_css("li", text: article.title)
+      end
+    end
+  end
+
+  context "with a bunch of articles" do
+    it "only lists the most recent 20 articles" do
+      recent_articles = FactoryBot.create_list(:article, 20)
+      older_article = FactoryBot.create(:article, title: "Older Article", created_at: 1.week.ago)
+      visit "/articles"
+      expect(page.all("li").count).to eq 20
+      expect(page).to have_no_content(older_article.title)
     end
   end
 end


### PR DESCRIPTION
A couple nice things here:

* use the article list page for finding recent articles - I picked 20 as the cut off
* link the article titles to their edit pages