### PR TITLE
feat: Editor edits article

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -10,6 +10,14 @@ class ArticlesController < ApplicationController
     end
   end
 
+  def update
+    if article.update(article_params)
+      redirect_to articles_path
+    else
+      render :edit
+    end
+  end
+
   private
 
   def article_params

--- a/app/views/articles/edit.html.haml
+++ b/app/views/articles/edit.html.haml
@@ -1,3 +1,5 @@
 %h1 Article #{article.id}
 
-%input{ name: "title", type: "text", value: article.title }
+= form_with model: article do |f|
+  = f.text_field :title, autofocus: true
+  = f.button "update"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
-  resources :articles, only: [:index, :edit, :new, :create]
+  resources :articles, only: [:index, :edit, :new, :create, :update]
   # root "home#index"
 end

--- a/spec/system/articles/editor_creates_article_spec.rb
+++ b/spec/system/articles/editor_creates_article_spec.rb
@@ -8,14 +8,13 @@ describe "create article" do
 
     fill_in "article[title]", with: "Brand New Article"
     click_button "create"
-    # this retries and that lets the POST complete
-    expect(page).to have_no_content "New Article"
+
+    expect(page).to have_current_path /edit/
 
     expect(Article.count).to eq 1
     article = Article.first
 
-    expect(page.current_path).to eq "/articles/#{article.id}/edit"
     expect(page).to have_content "Article #{article.id}"
-    expect(page).to have_field "title", with: article.title
+    expect(page).to have_field "article[title]", with: article.title
   end
 end

--- a/spec/system/articles/editor_edits_article_spec.rb
+++ b/spec/system/articles/editor_edits_article_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe "edit article" do
+  let(:article) { FactoryBot.create(:article, title: "Initial title") }
+
+  it "updates the article" do
+    visit "/articles/#{article.id}/edit"
+
+    expect(page).to have_field "article[title]", with: "Initial title"
+    fill_in "article[title]", with: "Updated title"
+    click_button "update"
+
+    expect(page).to have_current_path "/articles"
+    expect(page).to have_content "Updated title"
+  end
+end

--- a/spec/system/articles/editor_sees_article_spec.rb
+++ b/spec/system/articles/editor_sees_article_spec.rb
@@ -5,6 +5,6 @@ describe "article" do
     article = FactoryBot.create(:article)
     visit "/articles/#{article.id}/edit"
     expect(page).to have_content "Article #{article.id}"
-    expect(page).to have_field "title", with: article.title
+    expect(page).to have_field "article[title]", with: article.title
   end
 end


### PR DESCRIPTION
This one wires up the edit path properly. I also realized that I could use the `have_current_path` matcher in the create spec file because that uses the built-in retry behavior. Better.