### PR TITLE
feat: Add graphql api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gem "rails", "7.0.1"
 gem "bootsnap", require: false
 gem "decent_exposure"
 gem "graphql"
+gem "graphql-page_cursors"
+gem "graphql-rails_logger"
 gem "haml"
 gem "importmap-rails"
 gem "jbuilder"

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "rails", "7.0.1"
 
 gem "bootsnap", require: false
 gem "decent_exposure"
+gem "graphql"
 gem "haml"
 gem "importmap-rails"
 gem "jbuilder"
@@ -17,6 +18,7 @@ gem "stimulus-rails"
 gem "turbo-rails"
 
 group :development do
+  gem "graphiql-rails"
   gem "web-console"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,10 @@ GEM
       railties (>= 5.0.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    graphiql-rails (1.8.0)
+      railties
+      sprockets-rails
+    graphql (1.13.4)
     haml (5.2.2)
       temple (>= 0.8.0)
       tilt
@@ -256,6 +260,8 @@ DEPENDENCIES
   debug
   decent_exposure
   factory_bot_rails
+  graphiql-rails
+  graphql
   haml
   importmap-rails
   jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,13 @@ GEM
       railties
       sprockets-rails
     graphql (1.13.4)
+    graphql-page_cursors (0.0.2)
+      graphql
+    graphql-rails_logger (1.2.3)
+      actionpack (> 5.0)
+      activesupport (> 5.0)
+      railties (> 5.0)
+      rouge (~> 3.0)
     haml (5.2.2)
       temple (>= 0.8.0)
       tilt
@@ -190,6 +197,7 @@ GEM
     reline (0.3.1)
       io-console (~> 0.5)
     rexml (3.2.5)
+    rouge (3.27.0)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)
@@ -262,6 +270,8 @@ DEPENDENCIES
   factory_bot_rails
   graphiql-rails
   graphql
+  graphql-page_cursors
+  graphql-rails_logger
   haml
   importmap-rails
   jbuilder

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -1,0 +1,50 @@
+class GraphqlController < ApplicationController
+  # If accessing from outside this domain, nullify the session
+  # This allows for outside API access while preventing CSRF attacks,
+  # but you'll have to authenticate your user separately
+  # protect_from_forgery with: :null_session
+
+  def execute
+    variables = prepare_variables(params[:variables])
+    query = params[:query]
+    operation_name = params[:operationName]
+    context = {
+      # Query context goes here, for example:
+      # current_user: current_user,
+    }
+    result = NeutronSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
+    render json: result
+  rescue StandardError => e
+    raise e unless Rails.env.development?
+    handle_error_in_development(e)
+  end
+
+  private
+
+  # Handle variables in form data, JSON body, or a blank value
+  def prepare_variables(variables_param)
+    case variables_param
+    when String
+      if variables_param.present?
+        JSON.parse(variables_param) || {}
+      else
+        {}
+      end
+    when Hash
+      variables_param
+    when ActionController::Parameters
+      variables_param.to_unsafe_hash # GraphQL-Ruby will validate name and type of incoming variables.
+    when nil
+      {}
+    else
+      raise ArgumentError, "Unexpected parameter: #{variables_param}"
+    end
+  end
+
+  def handle_error_in_development(e)
+    logger.error e.message
+    logger.error e.backtrace.join("\n")
+
+    render json: { errors: [{ message: e.message, backtrace: e.backtrace }], data: {} }, status: 500
+  end
+end

--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -1,0 +1,8 @@
+module Mutations
+  class BaseMutation < GraphQL::Schema::RelayClassicMutation
+    argument_class Types::BaseArgument
+    field_class Types::BaseField
+    input_object_class Types::BaseInputObject
+    object_class Types::BaseObject
+  end
+end

--- a/app/graphql/neutron_schema.rb
+++ b/app/graphql/neutron_schema.rb
@@ -1,0 +1,51 @@
+class NeutronSchema < GraphQL::Schema
+  mutation(Types::MutationType)
+  query(Types::QueryType)
+
+  # For batch-loading (see https://graphql-ruby.org/dataloader/overview.html)
+  use GraphQL::Dataloader
+
+  # GraphQL-Ruby calls this when something goes wrong while running a query:
+  def self.type_error(err, context)
+    # if err.is_a?(GraphQL::InvalidNullError)
+    #   # report to your bug tracker here
+    #   return nil
+    # end
+    super
+  end
+
+  # Union and Interface Resolution
+  def self.resolve_type(abstract_type, obj, ctx)
+    # TODO: Implement this method
+    # to return the correct GraphQL object type for `obj`
+    raise(GraphQL::RequiredImplementationMissingError)
+  end
+
+  # Relay-style Object Identification:
+
+  # Return a string UUID for `object`
+  def self.id_from_object(object, type_definition, query_ctx)
+    # For example, use Rails' GlobalID library (https://github.com/rails/globalid):
+    object_id = object.to_global_id.to_s
+    # Remove this redundant prefix to make IDs shorter:
+    object_id = object_id.sub("gid://#{GlobalID.app}/", "")
+    encoded_id = Base64.urlsafe_encode64(object_id)
+    # Remove the "=" padding
+    encoded_id = encoded_id.sub(/=+/, "")
+    # Add a type hint
+    type_hint = type_definition.graphql_name.first
+    "#{type_hint}_#{encoded_id}"
+  end
+
+  # Given a string UUID, find the object
+  def self.object_from_id(encoded_id_with_hint, query_ctx)
+    # For example, use Rails' GlobalID library (https://github.com/rails/globalid):
+    # Split off the type hint
+    _type_hint, encoded_id = encoded_id_with_hint.split("_", 2)
+    # Decode the ID
+    id = Base64.urlsafe_decode64(encoded_id)
+    # Rebuild it for Rails then find the object:
+    full_global_id = "gid://#{GlobalID.app}/#{id}"
+    GlobalID::Locator.locate(full_global_id)
+  end
+end

--- a/app/graphql/types/article_connection_type.rb
+++ b/app/graphql/types/article_connection_type.rb
@@ -1,0 +1,9 @@
+module Types
+  class ArticleEdgeType < GraphQL::Types::Relay::BaseEdge
+    node_type(Types::ArticleType)
+  end
+
+  class ArticleConnectionType < GraphQL::PageCursorConnection
+    edge_type(Types::ArticleEdgeType)
+  end
+end

--- a/app/graphql/types/article_type.rb
+++ b/app/graphql/types/article_type.rb
@@ -1,0 +1,5 @@
+module Types
+  class ArticleType < Types::BaseObject
+    field :title, String
+  end
+end

--- a/app/graphql/types/base_argument.rb
+++ b/app/graphql/types/base_argument.rb
@@ -1,0 +1,4 @@
+module Types
+  class BaseArgument < GraphQL::Schema::Argument
+  end
+end

--- a/app/graphql/types/base_connection.rb
+++ b/app/graphql/types/base_connection.rb
@@ -1,0 +1,6 @@
+module Types
+  class BaseConnection < Types::BaseObject
+    # add `nodes` and `pageInfo` fields, as well as `edge_type(...)` and `node_nullable(...)` overrides
+    include GraphQL::Types::Relay::ConnectionBehaviors
+  end
+end

--- a/app/graphql/types/base_edge.rb
+++ b/app/graphql/types/base_edge.rb
@@ -1,0 +1,6 @@
+module Types
+  class BaseEdge < Types::BaseObject
+    # add `node` and `cursor` fields, as well as `node_type(...)` override
+    include GraphQL::Types::Relay::EdgeBehaviors
+  end
+end

--- a/app/graphql/types/base_enum.rb
+++ b/app/graphql/types/base_enum.rb
@@ -1,0 +1,4 @@
+module Types
+  class BaseEnum < GraphQL::Schema::Enum
+  end
+end

--- a/app/graphql/types/base_field.rb
+++ b/app/graphql/types/base_field.rb
@@ -1,0 +1,5 @@
+module Types
+  class BaseField < GraphQL::Schema::Field
+    argument_class Types::BaseArgument
+  end
+end

--- a/app/graphql/types/base_input_object.rb
+++ b/app/graphql/types/base_input_object.rb
@@ -1,0 +1,5 @@
+module Types
+  class BaseInputObject < GraphQL::Schema::InputObject
+    argument_class Types::BaseArgument
+  end
+end

--- a/app/graphql/types/base_interface.rb
+++ b/app/graphql/types/base_interface.rb
@@ -1,0 +1,9 @@
+module Types
+  module BaseInterface
+    include GraphQL::Schema::Interface
+    edge_type_class(Types::BaseEdge)
+    connection_type_class(Types::BaseConnection)
+
+    field_class Types::BaseField
+  end
+end

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -1,0 +1,7 @@
+module Types
+  class BaseObject < GraphQL::Schema::Object
+    edge_type_class(Types::BaseEdge)
+    connection_type_class(Types::BaseConnection)
+    field_class Types::BaseField
+  end
+end

--- a/app/graphql/types/base_scalar.rb
+++ b/app/graphql/types/base_scalar.rb
@@ -1,0 +1,4 @@
+module Types
+  class BaseScalar < GraphQL::Schema::Scalar
+  end
+end

--- a/app/graphql/types/base_union.rb
+++ b/app/graphql/types/base_union.rb
@@ -1,0 +1,6 @@
+module Types
+  class BaseUnion < GraphQL::Schema::Union
+    edge_type_class(Types::BaseEdge)
+    connection_type_class(Types::BaseConnection)
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,0 +1,10 @@
+module Types
+  class MutationType < Types::BaseObject
+    # TODO: remove me
+    field :test_field, String, null: false,
+      description: "An example field added by the generator"
+    def test_field
+      "Hello World"
+    end
+  end
+end

--- a/app/graphql/types/node_type.rb
+++ b/app/graphql/types/node_type.rb
@@ -1,0 +1,7 @@
+module Types
+  module NodeType
+    include Types::BaseInterface
+    # Add the `id` field
+    include GraphQL::Types::Relay::NodeBehaviors
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -1,0 +1,17 @@
+module Types
+  class QueryType < Types::BaseObject
+    # Add `node(id: ID!) and `nodes(ids: [ID!]!)`
+    include GraphQL::Types::Relay::HasNodeField
+    include GraphQL::Types::Relay::HasNodesField
+
+    # Add root-level fields here.
+    # They will be entry points for queries on your schema.
+
+    # TODO: remove me
+    field :test_field, String, null: false,
+      description: "An example field added by the generator"
+    def test_field
+      "Hello World!"
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -4,14 +4,21 @@ module Types
     include GraphQL::Types::Relay::HasNodeField
     include GraphQL::Types::Relay::HasNodesField
 
-    # Add root-level fields here.
-    # They will be entry points for queries on your schema.
+    field :article, ArticleType do
+      description "An Article."
+      argument :id, ID, required: true
+    end
 
-    # TODO: remove me
-    field :test_field, String, null: false,
-      description: "An example field added by the generator"
-    def test_field
-      "Hello World!"
+    def article(id:)
+      Article.find(id)
+    end
+
+    field :articles, ArticleConnectionType, connection: true do
+      description "A Connection of Articles."
+    end
+
+    def articles
+      Article.where(archived_at: nil)
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   if Rails.env.development?
-    mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/graphql"
+    mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/api/graphql"
   end
-  post "/graphql", to: "graphql#execute"
+  post "/api/graphql", to: "graphql#execute"
   resources :articles, only: [:index, :edit, :new, :create, :update, :destroy]
   # root "home#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  if Rails.env.development?
+    mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/graphql"
+  end
+  post "/graphql", to: "graphql#execute"
   resources :articles, only: [:index, :edit, :new, :create, :update, :destroy]
   # root "home#index"
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,6 +30,13 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
+
+module ApiHelpers
+  def response_json
+    JSON.parse(response.body)
+  end
+end
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
@@ -65,4 +72,6 @@ RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by :selenium, using: :headless_chrome
   end
+
+  config.include ApiHelpers, type: :request
 end

--- a/spec/requests/api/graphql/queries/article_spec.rb
+++ b/spec/requests/api/graphql/queries/article_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe 'article query' do
+  let(:article) { FactoryBot.create :article }
+
+  let(:query) { <<-GRAPHQL }
+    query {
+      article(id:#{article.id}) {
+        title
+      }
+    }
+  GRAPHQL
+
+  it 'returns that article' do
+    post '/api/graphql', params: { query: query }
+    expect(response.status).to eq 200
+    title = response_json.dig("data", "article", "title")
+    expect(title).to eq article.title
+  end
+end

--- a/spec/requests/api/graphql/queries/articles_spec.rb
+++ b/spec/requests/api/graphql/queries/articles_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe 'articles query' do
+  let(:query) { <<-GRAPHQL }
+    query {
+      articles(first:3) {
+        edges {
+          node {
+            title
+          }
+        }
+      }
+    }
+  GRAPHQL
+
+  it 'returns those articles' do
+    FactoryBot.create_list(:article, 3)
+    post '/api/graphql', params: { query: query }
+    expect(response.status).to eq 200
+    edges = response_json.dig('data', 'articles', 'edges')
+    expect(edges.count).to eq 3
+  end
+end


### PR DESCRIPTION
This is pretty easy to do! I followed the guidance over at https://graphql-ruby.org/ and when I got into trouble I looked up how things were setup over on convection. That lead me to remember the [graphql-page_cursors](https://github.com/artsy/graphql-page_cursors) gem we made last hackathon. I did add in some naive request specs that I can use to improve things including support for sorting etc.
<img width="1067" alt="Screen Shot 2022-01-11 at 3 22 37 PM" src="https://user-images.githubusercontent.com/79799/149023841-28dcedca-37da-49b9-90ef-cab1ad91dd75.png">

