### PR TITLE
feat: Extract LegacyArticles from Positron

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "rails", "7.0.1"
 
 gem "bootsnap", require: false
 gem "decent_exposure"
+gem "faraday"
 gem "graphql"
 gem "graphql-page_cursors"
 gem "graphql-rails_logger"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,10 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faraday (2.0.1)
+      faraday-net_http (~> 2.0)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (2.0.1)
     globalid (1.0.0)
       activesupport (>= 5.0)
     graphiql-rails (1.8.0)
@@ -215,6 +219,7 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.10.3)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
@@ -268,6 +273,7 @@ DEPENDENCIES
   debug
   decent_exposure
   factory_bot_rails
+  faraday
   graphiql-rails
   graphql
   graphql-page_cursors

--- a/app/models/legacy_article.rb
+++ b/app/models/legacy_article.rb
@@ -1,0 +1,8 @@
+class LegacyArticle < ApplicationRecord
+  def self.create_if_new(data)
+    positron_id = data.dig("_id", "$oid")
+    return if LegacyArticle.where(positron_id: positron_id).any?
+
+    LegacyArticle.create(data: data, positron_id: positron_id)
+  end
+end

--- a/db/migrate/20220111213914_create_legacy_articles.rb
+++ b/db/migrate/20220111213914_create_legacy_articles.rb
@@ -1,0 +1,10 @@
+class CreateLegacyArticles < ActiveRecord::Migration[7.0]
+  def change
+    create_table :legacy_articles do |t|
+      t.jsonb :data
+      t.string :positron_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -58,6 +58,38 @@ ALTER SEQUENCE public.articles_id_seq OWNED BY public.articles.id;
 
 
 --
+-- Name: legacy_articles; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.legacy_articles (
+    id bigint NOT NULL,
+    data jsonb,
+    positron_id character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: legacy_articles_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.legacy_articles_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: legacy_articles_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.legacy_articles_id_seq OWNED BY public.legacy_articles.id;
+
+
+--
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -71,6 +103,13 @@ CREATE TABLE public.schema_migrations (
 --
 
 ALTER TABLE ONLY public.articles ALTER COLUMN id SET DEFAULT nextval('public.articles_id_seq'::regclass);
+
+
+--
+-- Name: legacy_articles id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.legacy_articles ALTER COLUMN id SET DEFAULT nextval('public.legacy_articles_id_seq'::regclass);
 
 
 --
@@ -90,6 +129,14 @@ ALTER TABLE ONLY public.articles
 
 
 --
+-- Name: legacy_articles legacy_articles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.legacy_articles
+    ADD CONSTRAINT legacy_articles_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -105,6 +152,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20220111155643'),
-('20220111202235');
+('20220111202235'),
+('20220111213914');
 
 

--- a/lib/tasks/extract.rake
+++ b/lib/tasks/extract.rake
@@ -1,0 +1,20 @@
+task :extract, [:article_url] => :environment do |t, args|
+  starting_count = LegacyArticle.count
+
+  url = args.article_url
+  response = Faraday.get(url)
+  data = response.body
+  data.force_encoding("UTF-8")
+  json = JSON.parse(data)
+  puts "JSON parsed"
+
+  json.each do |data|
+    LegacyArticle.create_if_new(data)
+    print "."
+  end
+
+  created_count = LegacyArticle.count - starting_count
+
+  puts "\n all done!"
+  puts "created #{created_count} LegacyArticle records"
+end

--- a/spec/factories/legacy_article.rb
+++ b/spec/factories/legacy_article.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :legacy_article do
+    sequence(:positron_id) { |n| "asdf1234#{n}" }
+  end
+end

--- a/spec/models/legacy_article_spec.rb
+++ b/spec/models/legacy_article_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe LegacyArticle do
+  describe ".create_if_new" do
+    context "without an oid" do
+      let(:data) { { "title" => "Best Article" } }
+
+      it "creates that legacy article" do
+        expect {
+          LegacyArticle.create_if_new(data)
+        }.to change(LegacyArticle, :count).by(1)
+      end
+    end
+
+    context "with an oid that is new" do
+      let(:data) { { "_id" => { "$oid" => "new" }, "title" => "Best Article" } }
+
+      it "creates that legacy article" do
+        expect {
+          LegacyArticle.create_if_new(data)
+        }.to change(LegacyArticle, :count).by(1)
+      end
+    end
+
+    context "with an oid that is not new" do
+      let!(:legacy_article) { FactoryBot.create(:legacy_article, positron_id: "existing") }
+      let(:data) { { "_id" => { "$oid" => legacy_article.positron_id }, "title" => "Best Article" } }
+
+      it "does not create a legacy article" do
+        expect {
+          LegacyArticle.create_if_new(data)
+        }.not_to change(LegacyArticle, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Here what I've done is setup to be able to extract legacy articles from Positron - you run it like this:

```
$ bundle exec rake extract[https://example.com/articles.json]
```

This will seem to be hanging out doing nothing until Ruby has had a chance to parse all that JSON. From there it'll print a dot for each record it processes. At the end it'll tell you how many records were made.

I took some time to make it idempotent by using the mongo id - not perfect but good enough for our case imo.