### PR TITLE
feat: Migrate legacy articles by transforming their data

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,6 @@
 class Article < ApplicationRecord
+  has_one :legacy_article
+
   def archive
     update(archived_at: Time.now)
   end

--- a/app/models/article_transformer.rb
+++ b/app/models/article_transformer.rb
@@ -1,0 +1,35 @@
+class ArticleTransformer
+  def self.run(legacy_article_id)
+    new(legacy_article_id).run
+  end
+
+  def initialize(legacy_article_id)
+    @legacy_article_id = legacy_article_id
+  end
+
+  def run
+    article = Article.create(article_attrs)
+    legacy_article.update(transformed_at: Time.now, article_id: article.id)
+  end
+
+  private
+
+  def legacy_article
+    @legacy_article ||= LegacyArticle.find(@legacy_article_id)
+  end
+
+  def article_data
+    legacy_article.data
+  end
+
+  def article_attrs
+    {
+      created_at: article_data["updated_at"]["$date"],
+      legacy_article_id: legacy_article.id,
+      published_at: article_data["published_at"]["$date"],
+      title: article_data["title"],
+      updated_at: article_data["updated_at"]["$date"],
+    }
+  end
+end
+

--- a/app/models/legacy_article.rb
+++ b/app/models/legacy_article.rb
@@ -1,8 +1,14 @@
 class LegacyArticle < ApplicationRecord
+  has_one :article
+
   def self.create_if_new(data)
     positron_id = data.dig("_id", "$oid")
     return if LegacyArticle.where(positron_id: positron_id).any?
 
     LegacyArticle.create(data: data, positron_id: positron_id)
+  end
+
+  def transformed?
+    !transformed_at.nil?
   end
 end

--- a/db/migrate/20220112153446_add_fields_to_transform_articles.rb
+++ b/db/migrate/20220112153446_add_fields_to_transform_articles.rb
@@ -1,0 +1,13 @@
+class AddFieldsToTransformArticles < ActiveRecord::Migration[7.0]
+  def change
+    change_table :articles do |t|
+      t.references :legacy_article
+      t.datetime :published_at
+    end
+
+    change_table :legacy_articles do |t|
+      t.references :article
+      t.datetime :transformed_at
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -34,7 +34,9 @@ CREATE TABLE public.articles (
     title character varying,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    archived_at timestamp(6) without time zone
+    archived_at timestamp(6) without time zone,
+    legacy_article_id bigint,
+    published_at timestamp(6) without time zone
 );
 
 
@@ -66,7 +68,9 @@ CREATE TABLE public.legacy_articles (
     data jsonb,
     positron_id character varying,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    article_id bigint,
+    transformed_at timestamp(6) without time zone
 );
 
 
@@ -145,6 +149,20 @@ ALTER TABLE ONLY public.schema_migrations
 
 
 --
+-- Name: index_articles_on_legacy_article_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_articles_on_legacy_article_id ON public.articles USING btree (legacy_article_id);
+
+
+--
+-- Name: index_legacy_articles_on_article_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_legacy_articles_on_article_id ON public.legacy_articles USING btree (article_id);
+
+
+--
 -- PostgreSQL database dump complete
 --
 
@@ -153,6 +171,7 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20220111155643'),
 ('20220111202235'),
-('20220111213914');
+('20220111213914'),
+('20220112153446');
 
 

--- a/lib/tasks/transform.rake
+++ b/lib/tasks/transform.rake
@@ -1,0 +1,9 @@
+task transform: :environment do
+  article_ids_to_transform = LegacyArticle.where(transformed_at: nil).pluck(:id)
+  puts "Count of ids to transform: #{article_ids_to_transform.count}"
+
+  article_ids_to_transform.each do |legacy_article_id|
+    ArticleTransformer.run(legacy_article_id)
+    print "."
+  end
+end

--- a/spec/models/article_transformer_spec.rb
+++ b/spec/models/article_transformer_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe ArticleTransformer do
+  describe ".run" do
+    it "makes an article and updates the legacy article" do
+      data = {
+        "published_at" => { "$date" => "2012-08-21T19:27:23Z" },
+        "title" => "Best article",
+        "updated_at" => { "$date" => "2012-12-11T15:14:35Z" },
+      }
+
+      legacy_article = FactoryBot.create :legacy_article, data: data
+
+      expect do
+        ArticleTransformer.run(legacy_article.id)
+      end.to change(Article, :count).by(1)
+
+      legacy_article.reload
+
+      expect(legacy_article).to be_transformed
+      article = legacy_article.article
+
+      expect(article.legacy_article).to eq legacy_article
+
+      expect(article.created_at.iso8601).to eq legacy_article.data["updated_at"]["$date"]
+      expect(article.published_at.iso8601).to eq legacy_article.data["published_at"]["$date"]
+      expect(article.title).to eq legacy_article.data["title"]
+      expect(article.updated_at.iso8601).to eq legacy_article.data["updated_at"]["$date"]
+    end
+  end
+end


### PR DESCRIPTION
This PR gets us to a point where we have a full end-to-end workflow:

* export articles from Positron
* put them on the internet somewhere with a public url
* run the extract rake task with that url => creates `LegacyArticle` records
* run the transform task => creates `Article` records
* make an `article/articles` query via GraphQL and behold articles exist!

The only fields I've migrated here are title and some timestamps but with this in place incorporating more fields is about following the patterns.