### PR TITLE
feat: Support article slugs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "rails", "7.0.1"
 gem "bootsnap", require: false
 gem "decent_exposure"
 gem "faraday"
+gem "friendly_id"
 gem "graphql"
 gem "graphql-page_cursors"
 gem "graphql-rails_logger"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,8 @@ GEM
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (2.0.1)
+    friendly_id (5.4.2)
+      activerecord (>= 4.0.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
     graphiql-rails (1.8.0)
@@ -274,6 +276,7 @@ DEPENDENCIES
   decent_exposure
   factory_bot_rails
   faraday
+  friendly_id
   graphiql-rails
   graphql
   graphql-page_cursors

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,7 @@
 class Article < ApplicationRecord
+  extend FriendlyId
+  friendly_id :title, use: [:slugged, :history, :finders]
+
   has_one :legacy_article
 
   def archive

--- a/app/models/article_transformer.rb
+++ b/app/models/article_transformer.rb
@@ -24,12 +24,19 @@ class ArticleTransformer
 
   def article_attrs
     {
-      created_at: article_data["updated_at"]["$date"],
+      created_at: updated_at,
       legacy_article_id: legacy_article.id,
-      published_at: article_data["published_at"]["$date"],
+      published_at: article_data.dig("published_at", "$date"),
       title: article_data["title"],
-      updated_at: article_data["updated_at"]["$date"],
+      updated_at: updated_at,
     }
   end
-end
 
+  def updated_at
+    timestamp = article_data["updated_at"]
+
+    return timestamp if timestamp.nil? || timestamp.is_a?(String)
+
+    timestamp["$date"]
+  end
+end

--- a/app/models/article_transformer.rb
+++ b/app/models/article_transformer.rb
@@ -10,6 +10,9 @@ class ArticleTransformer
   def run
     article = Article.create(article_attrs)
     legacy_article.update(transformed_at: Time.now, article_id: article.id)
+    past_slugs.each do |slug|
+      article.slugs.create(slug: slug)
+    end
   end
 
   private
@@ -27,6 +30,7 @@ class ArticleTransformer
       created_at: updated_at,
       legacy_article_id: legacy_article.id,
       published_at: article_data.dig("published_at", "$date"),
+      slug: current_slug,
       title: article_data["title"],
       updated_at: updated_at,
     }
@@ -38,5 +42,16 @@ class ArticleTransformer
     return timestamp if timestamp.nil? || timestamp.is_a?(String)
 
     timestamp["$date"]
+  end
+
+  def current_slug
+    article_data["slug"]
+  end
+
+  def past_slugs
+    slugs = Array(article_data["slugs"])
+    return slugs unless slugs.any?
+
+    slugs - [current_slug]
   end
 end

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,0 +1,107 @@
+# FriendlyId Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `friendly_id` class method or defining
+# methods in your model.
+#
+# To learn more, check out the guide:
+#
+# http://norman.github.io/friendly_id/file.Guide.html
+
+FriendlyId.defaults do |config|
+  # ## Reserved Words
+  #
+  # Some words could conflict with Rails's routes when used as slugs, or are
+  # undesirable to allow as slugs. Edit this list as needed for your app.
+  config.use :reserved
+
+  config.reserved_words = %w(new edit index session login logout users admin
+    stylesheets assets javascripts images)
+    
+  # This adds an option to treat reserved words as conflicts rather than exceptions.
+  # When there is no good candidate, a UUID will be appended, matching the existing
+  # conflict behavior.
+
+  # config.treat_reserved_as_conflict = true
+
+  #  ## Friendly Finders
+  #
+  # Uncomment this to use friendly finders in all models. By default, if
+  # you wish to find a record by its friendly id, you must do:
+  #
+  #    MyModel.friendly.find('foo')
+  #
+  # If you uncomment this, you can do:
+  #
+  #    MyModel.find('foo')
+  #
+  # This is significantly more convenient but may not be appropriate for
+  # all applications, so you must explicity opt-in to this behavior. You can
+  # always also configure it on a per-model basis if you prefer.
+  #
+  # Something else to consider is that using the :finders addon boosts
+  # performance because it will avoid Rails-internal code that makes runtime
+  # calls to `Module.extend`.
+  #
+  # config.use :finders
+  #
+  # ## Slugs
+  #
+  # Most applications will use the :slugged module everywhere. If you wish
+  # to do so, uncomment the following line.
+  #
+  # config.use :slugged
+  #
+  # By default, FriendlyId's :slugged addon expects the slug column to be named
+  # 'slug', but you can change it if you wish.
+  #
+  # config.slug_column = 'slug'
+  #
+  # By default, slug has no size limit, but you can change it if you wish.
+  #
+  # config.slug_limit = 255
+  #
+  # When FriendlyId can not generate a unique ID from your base method, it appends
+  # a UUID, separated by a single dash. You can configure the character used as the
+  # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
+  # with two dashes.
+  #
+  # config.sequence_separator = '-'
+  #
+  # Note that you must use the :slugged addon **prior** to the line which
+  # configures the sequence separator, or else FriendlyId will raise an undefined
+  # method error.
+  #
+  #  ## Tips and Tricks
+  #
+  #  ### Controlling when slugs are generated
+  #
+  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
+  # nil, but if you're using a column as your base method can change this
+  # behavior by overriding the `should_generate_new_friendly_id?` method that
+  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
+  # more like 4.0.
+  # Note: Use(include) Slugged module in the config if using the anonymous module.
+  # If you have `friendly_id :name, use: slugged` in the model, Slugged module
+  # is included after the anonymous module defined in the initializer, so it
+  # overrides the `should_generate_new_friendly_id?` method from the anonymous module.
+  #
+  # config.use :slugged
+  # config.use Module.new {
+  #   def should_generate_new_friendly_id?
+  #     slug.blank? || <your_column_name_here>_changed?
+  #   end
+  # }
+  #
+  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
+  # languages that don't use the Roman alphabet, that's not usually sufficient.
+  # Here we use the Babosa library to transliterate Russian Cyrillic slugs to
+  # ASCII. If you use this, don't forget to add "babosa" to your Gemfile.
+  #
+  # config.use Module.new {
+  #   def normalize_friendly_id(text)
+  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #   end
+  # }
+end

--- a/db/migrate/20220113150807_create_friendly_id_slugs.rb
+++ b/db/migrate/20220113150807_create_friendly_id_slugs.rb
@@ -1,0 +1,14 @@
+class CreateFriendlyIdSlugs < ActiveRecord::Migration[7.0]
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,           :null => false
+      t.integer  :sluggable_id,   :null => false
+      t.string   :sluggable_type, :limit => 50
+      t.string   :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, [:sluggable_type, :sluggable_id]
+    add_index :friendly_id_slugs, [:slug, :sluggable_type], length: { slug: 140, sluggable_type: 50 }
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], length: { slug: 70, sluggable_type: 50, scope: 70 }, unique: true
+  end
+end

--- a/db/migrate/20220113150942_add_slug_to_articles.rb
+++ b/db/migrate/20220113150942_add_slug_to_articles.rb
@@ -1,0 +1,5 @@
+class AddSlugToArticles < ActiveRecord::Migration[7.0]
+  def change
+    add_column :articles, :slug, :string, uniq: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -60,6 +60,39 @@ ALTER SEQUENCE public.articles_id_seq OWNED BY public.articles.id;
 
 
 --
+-- Name: friendly_id_slugs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.friendly_id_slugs (
+    id bigint NOT NULL,
+    slug character varying NOT NULL,
+    sluggable_id integer NOT NULL,
+    sluggable_type character varying(50),
+    scope character varying,
+    created_at timestamp(6) without time zone
+);
+
+
+--
+-- Name: friendly_id_slugs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.friendly_id_slugs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: friendly_id_slugs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.friendly_id_slugs_id_seq OWNED BY public.friendly_id_slugs.id;
+
+
+--
 -- Name: legacy_articles; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -110,6 +143,13 @@ ALTER TABLE ONLY public.articles ALTER COLUMN id SET DEFAULT nextval('public.art
 
 
 --
+-- Name: friendly_id_slugs id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.friendly_id_slugs ALTER COLUMN id SET DEFAULT nextval('public.friendly_id_slugs_id_seq'::regclass);
+
+
+--
 -- Name: legacy_articles id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -130,6 +170,14 @@ ALTER TABLE ONLY public.ar_internal_metadata
 
 ALTER TABLE ONLY public.articles
     ADD CONSTRAINT articles_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: friendly_id_slugs friendly_id_slugs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.friendly_id_slugs
+    ADD CONSTRAINT friendly_id_slugs_pkey PRIMARY KEY (id);
 
 
 --
@@ -156,6 +204,27 @@ CREATE INDEX index_articles_on_legacy_article_id ON public.articles USING btree 
 
 
 --
+-- Name: index_friendly_id_slugs_on_slug_and_sluggable_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_friendly_id_slugs_on_slug_and_sluggable_type ON public.friendly_id_slugs USING btree (slug, sluggable_type);
+
+
+--
+-- Name: index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope ON public.friendly_id_slugs USING btree (slug, sluggable_type, scope);
+
+
+--
+-- Name: index_friendly_id_slugs_on_sluggable_type_and_sluggable_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_friendly_id_slugs_on_sluggable_type_and_sluggable_id ON public.friendly_id_slugs USING btree (sluggable_type, sluggable_id);
+
+
+--
 -- Name: index_legacy_articles_on_article_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -172,6 +241,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220111155643'),
 ('20220111202235'),
 ('20220111213914'),
-('20220112153446');
+('20220112153446'),
+('20220113150807');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -36,7 +36,8 @@ CREATE TABLE public.articles (
     updated_at timestamp(6) without time zone NOT NULL,
     archived_at timestamp(6) without time zone,
     legacy_article_id bigint,
-    published_at timestamp(6) without time zone
+    published_at timestamp(6) without time zone,
+    slug character varying
 );
 
 
@@ -242,6 +243,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220111202235'),
 ('20220111213914'),
 ('20220112153446'),
-('20220113150807');
+('20220113150807'),
+('20220113150942');
 
 

--- a/lib/tasks/transform.rake
+++ b/lib/tasks/transform.rake
@@ -5,5 +5,8 @@ task transform: :environment do
   article_ids_to_transform.each do |legacy_article_id|
     ArticleTransformer.run(legacy_article_id)
     print "."
+  rescue => e
+    puts e
+    puts legacy_article_id
   end
 end

--- a/spec/models/article_transformer_spec.rb
+++ b/spec/models/article_transformer_spec.rb
@@ -27,5 +27,23 @@ describe ArticleTransformer do
       expect(article.title).to eq legacy_article.data["title"]
       expect(article.updated_at.iso8601).to eq legacy_article.data["updated_at"]["$date"]
     end
+
+    it "sets the current slug and all past slugs" do
+      data = {
+        "published_at" => { "$date" => "2012-08-21T19:27:23Z" },
+        "slug" => "best-article-by-jon-allured",
+        "slugs" => ["best-article", "best-article-by-jon-allured"],
+        "title" => "Best article",
+        "updated_at" => { "$date" => "2012-12-11T15:14:35Z" },
+      }
+
+      legacy_article = FactoryBot.create :legacy_article, data: data
+      ArticleTransformer.run(legacy_article.id)
+
+      article = legacy_article.article
+
+      expect(article.slug).to eq legacy_article.data["slug"]
+      expect(Article.find("best-article")).to eq article
+    end
   end
 end


### PR DESCRIPTION
Adding support for article slugs was a little tricky but I ended up finding that `friendly_id` has default behavior that makes it pretty nice! What I've done here is update the transformer code to set the slug based on the legacy data and then also backfill any historical slugs. In terms of the graphql layer, slugs now "just work":

```
query {
  slugQuery:article(id:"artsy-editorial-expensive-artworks-sold-2021") {
    title
  }
  
  idQuery:article(id:"31935") {
    title
  }
}
```

Each of those queries returns the same article.